### PR TITLE
添加关注者接口支持

### DIFF
--- a/src/Youzan/Model/AccountDetail.php
+++ b/src/Youzan/Model/AccountDetail.php
@@ -21,4 +21,18 @@ class AccountDetail
     public $words;
     public $avatar;
     public $user_id;
+    public $weixin_openid;
+    public $weixin;
+    public $sex;
+    public $tags;
+    public $union_id;
+    public $is_follow;
+    public $points;
+    public $traded_num;
+    public $traded_money;
+    public $level_info;
+    public $nick;
+    public $follow_time;
+    public $province;
+    public $city;
 }

--- a/src/Youzan/Service/UserService.php
+++ b/src/Youzan/Service/UserService.php
@@ -27,4 +27,55 @@ class UserService extends BaseService
         }
         return ModelFactory::objectFromData($response['response'], AccountDetail::class);
     }
+
+    public function followerGet($user_id_or_openid, $fields = '')
+    {
+        $method = 'kdt.users.weixin.follower.get';
+        $params = array(
+            'fields' => $fields
+        );
+
+        $params[is_numeric($user_id_or_openid) ? 'user_id' : 'weixin_openid'] = $user_id_or_openid;
+
+        $response = $this->get($method, $params);
+        
+        if ($this->isResponseError($response)) {
+            return null;
+        }
+        return ModelFactory::objectFromData($response['response']['user'], AccountDetail::class);
+    }
+
+    public function followerGets(array $user_id_or_openids, $fields = '')
+    {
+        $method = 'kdt.users.weixin.follower.gets';
+
+        $user_ids = [];
+        $weixin_openids = [];
+
+        foreach($user_id_or_openids as $user_id_or_openid)
+        {
+            if(is_numeric($user_id_or_openid))
+            {
+                $user_ids[] = $user_id_or_openid;
+            }
+            else
+            {
+                $weixin_openids[] = $user_id_or_openid;
+            }
+        }
+
+        $params = array(
+            'fields' => $fields,
+            'user_ids' => implode(',', $user_ids),
+            'weixin_openids' => implode(',', $weixin_openids)
+        );
+
+        $response = $this->get($method, $params);
+
+        if ($this->isResponseError($response)) {
+            return null;
+        }
+        return ModelFactory::objectListFromData($response['response']['user'], AccountDetail::class);
+    }
+
 }

--- a/src/Youzan/Youzan.php
+++ b/src/Youzan/Youzan.php
@@ -3,8 +3,8 @@
 /**
  * Created by PhpStorm.
  * User: imhui
- * Date: 16/3/7
- * Time: 12:24
+ * Date: 16/7/7
+ * Time: 15:41
  */
 
 namespace Youzan;
@@ -16,6 +16,7 @@ use Youzan\Service\GoodsService;
 use Youzan\Service\LogisticsService;
 use Youzan\Service\ShopService;
 use Youzan\Service\TradeService;
+use Youzan\Service\UserService;
 
 class Youzan
 {
@@ -58,6 +59,11 @@ class Youzan
      */
     private $shopService = null;
 
+    /**
+     * @var UserService
+     */
+    private $userService = null;
+    
     /**
      * Youzan constructor.
      * @param $appId
@@ -128,4 +134,15 @@ class Youzan
         return $this->shopService;
     }
 
+    /**
+     * @return UserService
+     */
+    public function user()
+    {
+        if (!$this->userService) {
+            $this->userService = new UserService($this->apiClient, $this->cacheDir);
+        }
+        return $this->userService;
+    }
+    
 }


### PR DESCRIPTION
我在Laravel中使用你的项目对接有赞，发现订单列表拿到的只有buyer_id，没有微信openid，于是增加了获得关注者的支持。
